### PR TITLE
Credential reorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains tools to help with interacting with Maven repositories 
 Requests to Artifact Registry will be authenticated using credentials from the environment. The
 tools described below search the environment for credentials in the following order:
 1. [Google Application Default Credentials](https://developers.google.com/accounts/docs/application-default-credentials).
-    * Note: It is possible to set Application Default Credentials for a personal account via `gcloud auth login --update-adc` or `gcloud auth application-default login`
+    * Note: It is possible to set Application Default Credentials for a user account via `gcloud auth login --update-adc` or `gcloud auth application-default login`
 1. From the `gcloud` SDK. (i.e., the access token printed via `gcloud config config-helper --format='value(credential.access_token)'`)
     * Hint: You can see which account is active with the command `gcloud config config-helper --format='value(configuration.properties.core.account)'`
 
@@ -24,7 +24,7 @@ To enable the wagon, add the following configuration to the `pom.xml` in your pr
         <extension>
             <groupId>com.google.cloud.artifactregistry</groupId>
             <artifactId>artifactregistry-maven-wagon</artifactId>
-            <version>2.0.1</version>
+            <version>2.1.0</version>
         </extension>
     </extensions>
 ```
@@ -61,7 +61,7 @@ you should use the correct location for your repository.
 
 ```gradle
 plugins {
-  id "com.google.cloud.artifactregistry.gradle-plugin" version "2.0.1"
+  id "com.google.cloud.artifactregistry.gradle-plugin" version "2.1.0"
 }
 
 repositories {
@@ -97,7 +97,7 @@ initscript {
     }
   }
   dependencies {
-    classpath "gradle.plugin.com.google.cloud.artifactregistry:artifactregistry-gradle-plugin:2.0.1"
+    classpath "gradle.plugin.com.google.cloud.artifactregistry:artifactregistry-gradle-plugin:2.1.0"
   }
 }
 
@@ -114,7 +114,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath "gradle.plugin.com.google.cloud.artifactregistry:artifactregistry-gradle-plugin:2.0.1"
+    classpath "gradle.plugin.com.google.cloud.artifactregistry:artifactregistry-gradle-plugin:2.1.0"
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ This repository contains tools to help with interacting with Maven repositories 
 
 Requests to Artifact Registry will be authenticated using credentials from the environment. The
 tools described below search the environment for credentials in the following order:
+1. [Google Application Default Credentials](https://developers.google.com/accounts/docs/application-default-credentials).
+    * Note: It is possible to set Application Default Credentials for a personal account via `gcloud auth login --update-adc` or `gcloud auth application-default login`
 1. From the `gcloud` SDK. (i.e., the access token printed via `gcloud config config-helper --format='value(credential.access_token)'`)
     * Hint: You can see which account is active with the command `gcloud config config-helper --format='value(configuration.properties.core.account)'`
-1. [Google Application Default Credentials](https://developers.google.com/accounts/docs/application-default-credentials).
 
 ## Maven Setup
 
@@ -55,7 +56,7 @@ Where
 ## Gradle Setup
 
 To use Artifact Registry repositories with gradle, add the following configuration to the
-`build.gradle` file in your project. In this example the repository is in 'us-west1', 
+`build.gradle` file in your project. In this example the repository is in 'us-west1',
 you should use the correct location for your repository.
 
 ```gradle
@@ -84,7 +85,7 @@ Where
 
 ### Alternatives
 
-If you need to use Artifact Registry repositories inside your `init.gradle` or `settings.gradle`, the plugin can also be used inside `init.gradle` or `settings.gradle` files. 
+If you need to use Artifact Registry repositories inside your `init.gradle` or `settings.gradle`, the plugin can also be used inside `init.gradle` or `settings.gradle` files.
 
 * To use plugin inside `init.gradle` file:
 

--- a/artifactregistry-auth-common/build.gradle
+++ b/artifactregistry-auth-common/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     compile group: 'com.google.http-client', name: 'google-http-client', version:'1.30.2'
     compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version:'0.16.2'
+    compile group: 'org.slf4j', name: 'slf4j-api', version:'1.7.30'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }

--- a/artifactregistry-auth-common/src/main/java/com/google/cloud/artifactregistry/auth/DefaultCredentialProvider.java
+++ b/artifactregistry-auth-common/src/main/java/com/google/cloud/artifactregistry/auth/DefaultCredentialProvider.java
@@ -19,21 +19,40 @@ package com.google.cloud.artifactregistry.auth;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 // DefaultCredentialProvider fetches credentials from gcloud and falls back to Application Default
 // Credentials if that fails.
 public class DefaultCredentialProvider implements CredentialProvider {
+  private static final Logger LOGGER = LoggerFactory.getLogger(GcloudCredentials.class.getName());
 
   private static String[] SCOPES = {"https://www.googleapis.com/auth/cloud-platform",
       "https://www.googleapis.com/auth/cloud-platform.read-only"};
 
   @Override
   public Credentials getCredential() throws IOException {
+    LOGGER.info("ArtifactRegistry Maven Wagon: Retrieving credentials...");
     Credentials credentials;
-    credentials = GcloudCredentials.tryCreateGcloudCredentials();
-    if (credentials != null) {
+
+    LOGGER.info("Trying Application Default Credentials...");
+    try {
+      credentials = GoogleCredentials.getApplicationDefault().createScoped(SCOPES);
+      LOGGER.info("Using Application Default Credentials.");
       return credentials;
+    } catch (IOException ex) {
+      LOGGER.info("Failed to retrieve Application Default Credentials: " + ex.getMessage());
     }
-    return GoogleCredentials.getApplicationDefault().createScoped(SCOPES);
+
+    LOGGER.info("Trying to retrieve credentials from gcloud...");
+    try {
+      credentials = GcloudCredentials.tryCreateGcloudCredentials();
+      LOGGER.info("Using credentials retrieved from gcloud.");
+      return credentials;
+    } catch (IOException ex) {
+      LOGGER.info("Failed to retrieve credentials from gcloud: " + ex.getMessage());
+    }
+    LOGGER.info("ArtifactRegistry Maven Wagon: No credentials could be found.");
+    throw new IOException("Failed to find credentials Check info logs for more details.");
   }
 }

--- a/artifactregistry-auth-common/src/main/java/com/google/cloud/artifactregistry/auth/DefaultCredentialProvider.java
+++ b/artifactregistry-auth-common/src/main/java/com/google/cloud/artifactregistry/auth/DefaultCredentialProvider.java
@@ -52,6 +52,7 @@ public class DefaultCredentialProvider implements CredentialProvider {
     } catch (IOException ex) {
       LOGGER.info("Failed to retrieve credentials from gcloud: " + ex.getMessage());
     }
+    
     LOGGER.info("ArtifactRegistry Maven Wagon: No credentials could be found.");
     throw new IOException("Failed to find credentials Check info logs for more details.");
   }

--- a/artifactregistry-auth-common/src/main/java/com/google/cloud/artifactregistry/auth/DefaultCredentialProvider.java
+++ b/artifactregistry-auth-common/src/main/java/com/google/cloud/artifactregistry/auth/DefaultCredentialProvider.java
@@ -52,7 +52,7 @@ public class DefaultCredentialProvider implements CredentialProvider {
     } catch (IOException ex) {
       LOGGER.info("Failed to retrieve credentials from gcloud: " + ex.getMessage());
     }
-    
+
     LOGGER.info("ArtifactRegistry Maven Wagon: No credentials could be found.");
     throw new IOException("Failed to find credentials Check info logs for more details.");
   }

--- a/artifactregistry-auth-common/src/main/java/com/google/cloud/artifactregistry/auth/GcloudCredentials.java
+++ b/artifactregistry-auth-common/src/main/java/com/google/cloud/artifactregistry/auth/GcloudCredentials.java
@@ -20,8 +20,6 @@ import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.util.GenericData;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
-import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -31,23 +29,16 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
 import java.util.TimeZone;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class GcloudCredentials extends GoogleCredentials {
 
   private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
-  private static final Logger LOGGER = LoggerFactory.getLogger(GcloudCredentials.class.getName());
-
   private static final String KEY_ACCESS_TOKEN = "access_token";
   private static final String KEY_TOKEN_EXPIRY = "token_expiry";
 
   private GcloudCredentials(AccessToken initialToken) {
     super(initialToken);
   }
-
-
-
 
   @Override
   public AccessToken refreshAccessToken() throws IOException {
@@ -63,7 +54,7 @@ public class GcloudCredentials extends GoogleCredentials {
     try {
       return new GcloudCredentials(getGcloudAccessToken());
     } catch (IOException e) {
-      throw new IOException("Failed to get credentials from gcloud: " + e.getMessage());
+      throw new IOException("Failed to get access token from gcloud: " + e.getMessage());
     }
   }
 

--- a/artifactregistry-auth-common/src/main/java/com/google/cloud/artifactregistry/auth/GcloudCredentials.java
+++ b/artifactregistry-auth-common/src/main/java/com/google/cloud/artifactregistry/auth/GcloudCredentials.java
@@ -20,6 +20,7 @@ import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.util.GenericData;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
+import java.io.File;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -27,12 +28,13 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
 import java.util.TimeZone;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GcloudCredentials extends GoogleCredentials {
 
   private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
-  private static final Logger LOGGER = Logger.getLogger(GcloudCredentials.class.getName());
+  private static final Logger LOGGER = LoggerFactory.getLogger(GcloudCredentials.class.getName());
 
   private static final String KEY_ACCESS_TOKEN = "access_token";
   private static final String KEY_TOKEN_EXPIRY = "token_expiry";
@@ -48,13 +50,14 @@ public class GcloudCredentials extends GoogleCredentials {
 
   /**
    * Tries to get credentials from gcloud. Returns null if credentials are not available.
+   * @return The Credentials from gcloud
+   * @throws IOException if there was an error retrieving credentials from gcloud
    */
-  public static GcloudCredentials tryCreateGcloudCredentials() {
+  public static GcloudCredentials tryCreateGcloudCredentials() throws IOException {
     try {
       return new GcloudCredentials(getGcloudAccessToken());
     } catch (IOException e) {
-      LOGGER.fine("Failed to get credentials from gcloud: " + e.getMessage());
-      return null;
+      throw new IOException("Failed to get credentials from gcloud: " + e.getMessage());
     }
   }
 

--- a/artifactregistry-auth-common/src/main/java/com/google/cloud/artifactregistry/auth/GcloudCredentials.java
+++ b/artifactregistry-auth-common/src/main/java/com/google/cloud/artifactregistry/auth/GcloudCredentials.java
@@ -109,5 +109,4 @@ public class GcloudCredentials extends GoogleCredentials {
     }
     return output.toString();
   }
-
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
 }
 
 description = 'Artifact Registry Maven Tools'
-ext.project_version = '2.0.2-SNAPSHOT'
+ext.project_version = '2.1.0-SNAPSHOT'
 ext.isReleaseVersion = !project_version.endsWith("SNAPSHOT")
 
 allprojects {


### PR DESCRIPTION
This changes the ordering of lookup for authentication so that ADC are checked first. This is important as ADC is the primary way of setting credentials on automated systems. 

Gcloud is tried second as a fallback. If gcloud returns an error the stdout and stderr are included in the error message.

Bumps version to 2.1.0-SNAPSHOT

The error message for the complete failure case now looks like this:

[INFO] ArtifactRegistry Maven Wagon: Retrieving credentials...
[INFO] Trying Application Default Credentials...
May 18, 2020 9:03:43 AM com.google.auth.oauth2.ComputeEngineCredentials runningOnComputeEngine
INFO: Failed to detect whether we are running on Google Compute Engine.
[INFO] Failed to retrieve Application Default Credentials: The Application Default Credentials are not available. They are available if running in Google Compute Engine. Otherwise, the environment variable GOOGLE_APPLICATION_CREDENTIALS must be defined pointing to a file defining the credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.
[INFO] Trying to retrieve credentials from gcloud...
[INFO] Failed to retrieve credentials from gcloud: Failed to get access token from gcloud: gcloud exited with status: 1
Output:

Error Output:
ERROR: (gcloud.config.config-helper) You do not currently have an active account selected.
Please run:

  $ gcloud auth login

to obtain new credentials, or if you have already logged in with a
different account:

  $ gcloud config set account ACCOUNT

to select an already authenticated account to use.


[INFO] ArtifactRegistry Maven Wagon: No credentials could be found.
