### PR TITLE
Fix for Gradle 7 Compatibility

### DIFF
--- a/artifactregistry-gradle-plugin/src/main/java/com/google/cloud/artifactregistry/gradle/plugin/ArtifactRegistryGradlePlugin.java
+++ b/artifactregistry-gradle-plugin/src/main/java/com/google/cloud/artifactregistry/gradle/plugin/ArtifactRegistryGradlePlugin.java
@@ -36,6 +36,7 @@ import org.gradle.api.internal.artifacts.repositories.DefaultMavenArtifactReposi
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.provider.Property;
 import org.gradle.api.publish.PublishingExtension;
+import org.gradle.api.tasks.Input;
 import org.gradle.internal.authentication.DefaultBasicAuthentication;
 import org.gradle.plugin.management.PluginManagementSpec;
 import org.slf4j.Logger;
@@ -54,11 +55,13 @@ public class ArtifactRegistryGradlePlugin implements Plugin<Object> {
       this.password = password;
     }
 
+    @Input
     @Override
     public String getUsername() {
       return username;
     }
 
+    @Input
     @Override
     public String getPassword() {
       return password;


### PR DESCRIPTION
The `gw publish` throws the following error while used with gradle `7.0.2`. 
```
Type 'org.gradle.api.publish.maven.tasks.PublishToMavenRepository' property 'credentials.password' is missing an input or output annotation.    
Reason: A property without annotation isn't considered during up-to-date checking.
Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.
```
Fixes [#46](https://github.com/GoogleCloudPlatform/artifact-registry-maven-tools/issues/46)