### PR TITLE
Set read timeout to the default value from AbstractWagon

### DIFF
--- a/artifactregistry-maven-wagon/src/main/java/com/google/cloud/artifactregistry/wagon/ArtifactRegistryRequestInitializer.java
+++ b/artifactregistry-maven-wagon/src/main/java/com/google/cloud/artifactregistry/wagon/ArtifactRegistryRequestInitializer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.artifactregistry.wagon;
+
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.auth.Credentials;
+import com.google.auth.http.HttpCredentialsAdapter;
+import java.io.IOException;
+
+/**
+ * ArtifactRegistryRequestInitializer initializes outbound requests with the provided credentials and read timeout. 
+ */
+public class ArtifactRegistryRequestInitializer implements HttpRequestInitializer {
+
+  private HttpCredentialsAdapter credentialsAdapter;
+  private int readTimeout;
+
+  ArtifactRegistryRequestInitializer(Credentials credentials, int readTimeout) {
+    this.credentialsAdapter = new HttpCredentialsAdapter(credentials);
+    this.readTimeout = readTimeout;
+  }
+
+  @Override
+  public void initialize(HttpRequest request) throws IOException {
+    this.credentialsAdapter.initialize(request);
+    request.setReadTimeout(readTimeout);
+  }
+}

--- a/artifactregistry-maven-wagon/src/main/java/com/google/cloud/artifactregistry/wagon/ArtifactRegistryWagon.java
+++ b/artifactregistry-maven-wagon/src/main/java/com/google/cloud/artifactregistry/wagon/ArtifactRegistryWagon.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.artifactregistry.wagon;
 
-
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpContent;
 import com.google.api.client.http.HttpRequest;
@@ -74,11 +73,10 @@ public final class ArtifactRegistryWagon extends AbstractWagon {
 
   @Override
   protected void openConnectionInternal() throws ConnectionException, AuthenticationException {
-    HttpRequestInitializer requestInitializer;
     HttpTransport httpTransport = httpTransportFactory.create();
     try {
       credentials = credentialProvider.getCredential();
-      requestInitializer = new HttpCredentialsAdapter(credentials);
+      HttpRequestInitializer requestInitializer = new ArtifactRegistryRequestInitializer(credentials, this.getReadTimeout());
       requestFactory = httpTransport.createRequestFactory(requestInitializer);
       hasCredentials = true;
     } catch (IOException e) {

--- a/artifactregistry-maven-wagon/src/test/java/com/google/cloud/artifactregistry/wagon/ArtifactRegistryRequestInitializerTest.java
+++ b/artifactregistry-maven-wagon/src/test/java/com/google/cloud/artifactregistry/wagon/ArtifactRegistryRequestInitializerTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.artifactregistry.wagon;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.client.testing.http.MockLowLevelHttpRequest;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import com.google.auth.Credentials;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.http.HttpTransportFactory;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.time.Instant;
+import java.util.Date;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+
+@RunWith(JUnit4.class)
+public class ArtifactRegistryRequestInitializerTest {
+
+  @Test
+  public void testInitialize() throws Exception {
+    Credentials creds = GoogleCredentials.create(new AccessToken("test-access-token", Date.from(
+        Instant.now().plusSeconds(1000))));
+    ArtifactRegistryRequestInitializer initializer = new ArtifactRegistryRequestInitializer(creds, 100);
+    MockHttpTransport transport = new MockHttpTransport.Builder()
+        .setLowLevelHttpResponse(new MockLowLevelHttpResponse().setContent("test content"))
+        .build();
+    GenericUrl url = new GenericUrl("https://www.example.com");
+    HttpRequestFactory requestFactory = transport.createRequestFactory(initializer);
+    HttpRequest request = requestFactory.buildHeadRequest(url);
+    Assert.assertEquals(request.getReadTimeout(), 100);
+    Assert.assertEquals(request.getHeaders().getFirstHeaderStringValue("Authorization"), "Bearer test-access-token");
+  }
+}

--- a/artifactregistry-maven-wagon/src/test/java/com/google/cloud/artifactregistry/wagon/ArtifactRegistryWagonTest.java
+++ b/artifactregistry-maven-wagon/src/test/java/com/google/cloud/artifactregistry/wagon/ArtifactRegistryWagonTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.artifactregistry.wagon;
 
 import com.google.api.client.http.HttpHeaders;


### PR DESCRIPTION
Create a custom `ArtifactRegistryRequestInitializer` that implements `HttpRequestInitializer`, it does two things:
- attach credentials to outbound requests
- set read timeout to outbound requests

The read timeout is set to `AbstractWagon.getReadTimeout()`, which has a default value of 30 minutes if not overriden by user settings.