### PR TITLE
chore: update dependencies

### DIFF
--- a/artifactregistry-auth-common/build.gradle
+++ b/artifactregistry-auth-common/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile group: 'com.google.http-client', name: 'google-http-client', version:'1.39.2'
-    compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version:'1.0.0'
+    compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version:'0.27.0'
     compile group: 'org.slf4j', name: 'slf4j-api', version:'1.7.30'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }

--- a/artifactregistry-auth-common/build.gradle
+++ b/artifactregistry-auth-common/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
-    compile group: 'com.google.http-client', name: 'google-http-client', version:'1.30.2'
-    compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version:'0.16.2'
+    compile group: 'com.google.http-client', name: 'google-http-client', version:'1.39.2'
+    compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version:'1.0.0'
     compile group: 'org.slf4j', name: 'slf4j-api', version:'1.7.30'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }

--- a/artifactregistry-auth-common/build.gradle
+++ b/artifactregistry-auth-common/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     compile group: 'com.google.http-client', name: 'google-http-client', version:'1.39.2'
-    compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version:'0.27.0'
+    compile group: 'com.google.http-client', name: 'google-http-client-jackson2', version:'1.39.2'
+    compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version:'1.0.0'
     compile group: 'org.slf4j', name: 'slf4j-api', version:'1.7.30'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }

--- a/artifactregistry-gradle-plugin/build.gradle
+++ b/artifactregistry-gradle-plugin/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
 	compile gradleApi()
-	compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '0.16.2'
+	compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '1.0.0'
 }
 
 pluginBundle {

--- a/artifactregistry-gradle-plugin/build.gradle
+++ b/artifactregistry-gradle-plugin/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
 	compile gradleApi()
-	compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '0.27.0'
+	compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '1.0.0'
 }
 
 pluginBundle {

--- a/artifactregistry-gradle-plugin/build.gradle
+++ b/artifactregistry-gradle-plugin/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
 	compile gradleApi()
-	compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '1.0.0'
+	compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '0.27.0'
 }
 
 pluginBundle {

--- a/artifactregistry-maven-wagon/build.gradle
+++ b/artifactregistry-maven-wagon/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
     compile group: 'org.apache.maven.wagon', name: 'wagon-http-shared', version: '3.3.3'
     compile group: 'org.apache.maven', name: 'maven-plugin-api', version: '3.6.1'
-    compile group: 'com.google.http-client', name: 'google-http-client', version: '1.39.2'
-    compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '0.27.0'
+    compile group: 'com.google.http-client', name: 'google-http-client', version:'1.39.2'
+    compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version:'1.0.0'
     testCompile group: 'org.apache.maven.wagon', name: 'wagon-provider-test', version: '3.3.3'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     compileOnly group: 'org.apache.maven.wagon', name: 'wagon-provider-api', version: '3.3.3'

--- a/artifactregistry-maven-wagon/build.gradle
+++ b/artifactregistry-maven-wagon/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     compile group: 'org.apache.maven.wagon', name: 'wagon-http-shared', version: '3.3.3'
     compile group: 'org.apache.maven', name: 'maven-plugin-api', version: '3.6.1'
     compile group: 'com.google.http-client', name: 'google-http-client', version: '1.39.2'
-    compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '1.0.0'
+    compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '0.27.0'
     testCompile group: 'org.apache.maven.wagon', name: 'wagon-provider-test', version: '3.3.3'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     compileOnly group: 'org.apache.maven.wagon', name: 'wagon-provider-api', version: '3.3.3'

--- a/artifactregistry-maven-wagon/build.gradle
+++ b/artifactregistry-maven-wagon/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
     compile group: 'org.apache.maven.wagon', name: 'wagon-http-shared', version: '3.3.3'
     compile group: 'org.apache.maven', name: 'maven-plugin-api', version: '3.6.1'
-    compile group: 'com.google.http-client', name: 'google-http-client', version: '1.30.2'
-    compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '0.16.2'
+    compile group: 'com.google.http-client', name: 'google-http-client', version: '1.39.2'
+    compile group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '1.0.0'
     testCompile group: 'org.apache.maven.wagon', name: 'wagon-provider-test', version: '3.3.3'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     compileOnly group: 'org.apache.maven.wagon', name: 'wagon-provider-api', version: '3.3.3'


### PR DESCRIPTION
Update google-http-client and google-auth-library-oauth2-http to the latest version.

Also explicitly depend on jackson2 becuase google-auth-library-oauth2-http stopped depending on jackson2 after 0.16.2 so we loose it as a transitive dependency.

Fix #27
Fix #44 