### PR TITLE
Release 2.1.3 and bump to the next snapshot version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
 }
 
 description = 'Artifact Registry Maven Tools'
-ext.project_version = '2.1.3'
+ext.project_version = '2.1.4-SNAPSHOT'
 ext.isReleaseVersion = !project_version.endsWith("SNAPSHOT")
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
 }
 
 description = 'Artifact Registry Maven Tools'
-ext.project_version = '2.1.3-SNAPSHOT'
+ext.project_version = '2.1.3'
 ext.isReleaseVersion = !project_version.endsWith("SNAPSHOT")
 
 allprojects {


### PR DESCRIPTION
Both the gradle plugin and the maven wagon are published:
- gradle plugin v2.1.3: https://plugins.gradle.org/plugin/com.google.cloud.artifactregistry.gradle-plugin
- maven wagon v2.1.3: https://repo.maven.apache.org/maven2/com/google/cloud/artifactregistry/artifactregistry-maven-wagon/2.1.3/