### PR TITLE
Add instructions upon parent pom usage. Bump version numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To enable the wagon, add the following configuration to the `pom.xml` in your pr
         <extension>
             <groupId>com.google.cloud.artifactregistry</groupId>
             <artifactId>artifactregistry-maven-wagon</artifactId>
-            <version>2.1.4</version>
+            <version>2.2.0</version>
         </extension>
     </extensions>
 ```
@@ -53,6 +53,12 @@ Where
 * **PROJECT_ID** is the ID of the project.
 * **REPOSITORY_ID** is the ID of the repository.
 
+### Parent Pom Usage
+
+To use a parent pom definition hosted at an Artifact Registry repository, some extra configuration is needed.
+These can be found
+at [Authenticating with a credential helper, step 6](https://cloud.google.com/artifact-registry/docs/java/authentication#auth-helper)
+
 ## Gradle Setup
 
 To use Artifact Registry repositories with gradle, add the following configuration to the
@@ -61,7 +67,7 @@ you should use the correct location for your repository.
 
 ```gradle
 plugins {
-  id "com.google.cloud.artifactregistry.gradle-plugin" version "2.1.4"
+  id "com.google.cloud.artifactregistry.gradle-plugin" version "2.2.0"
 }
 
 repositories {
@@ -97,7 +103,7 @@ initscript {
     }
   }
   dependencies {
-    classpath "gradle.plugin.com.google.cloud.artifactregistry:artifactregistry-gradle-plugin:2.1.4"
+    classpath "gradle.plugin.com.google.cloud.artifactregistry:artifactregistry-gradle-plugin:2.2.0"
   }
 }
 
@@ -114,7 +120,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath "gradle.plugin.com.google.cloud.artifactregistry:artifactregistry-gradle-plugin:2.1.4"
+    classpath "gradle.plugin.com.google.cloud.artifactregistry:artifactregistry-gradle-plugin:2.2.0"
   }
 }
 


### PR DESCRIPTION
I've been puzzling with the parent pom configuration to find out why it did not work out of the box. Adding this explanation here will help future developers find it quicker.

Next to that, bumped version of the current release.