### PR TITLE
Add `dependencyResolutionManagement` support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gradle/
 .idea/
 build/
+local.properties

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To enable the wagon, add the following configuration to the `pom.xml` in your pr
         <extension>
             <groupId>com.google.cloud.artifactregistry</groupId>
             <artifactId>artifactregistry-maven-wagon</artifactId>
-            <version>2.2.1</version>
+            <version>2.2.4</version>
         </extension>
     </extensions>
 ```
@@ -67,7 +67,7 @@ you should use the correct location for your repository.
 
 ```gradle
 plugins {
-  id "com.google.cloud.artifactregistry.gradle-plugin" version "2.2.1"
+  id "com.google.cloud.artifactregistry.gradle-plugin" version "2.2.4"
 }
 
 repositories {
@@ -89,6 +89,40 @@ Where
 * **PROJECT_ID** is the ID of the project.
 * **REPOSITORY_ID** is the ID of the repository.
 
+### Using the Dependency Resolution Management block in settings.gradle
+
+The incubating but well supported [`dependenciesResolutionManagement` block](https://docs.gradle.org/current/userguide/centralizing_repositories.html) provides
+a way to declare dependency repositories in a single project-wide location, within the `settings.gradle` file.
+
+```gradle
+plugins {
+  id "com.google.cloud.artifactregistry.gradle-plugin" version "2.2.4"
+}
+
+dependencyResolutionManagement {
+    repositories {
+        maven {
+            url 'artifactregistry://us-west1-maven.pkg.dev/PROJECT_ID/REPOSITORY_ID'
+        }
+    }
+}
+```
+
+For `settings.gradle.kts` (Kotlin script) files:
+```kotlin
+plugins {
+  id("com.google.cloud.artifactregistry.gradle-plugin").version("2.2.4")
+}
+
+dependencyResolutionManagement {
+    repositories {
+        maven {
+            url = uri("artifactregistry://us-west1-maven.pkg.dev/PROJECT_ID/REPOSITORY_ID")
+        }
+    }
+}
+```
+
 ### Alternatives
 
 If you need to use Artifact Registry repositories inside your `init.gradle` or `settings.gradle`, the plugin can also be used inside `init.gradle` or `settings.gradle` files.
@@ -103,7 +137,7 @@ initscript {
     }
   }
   dependencies {
-    classpath "gradle.plugin.com.google.cloud.artifactregistry:artifactregistry-gradle-plugin:2.2.1"
+    classpath "gradle.plugin.com.google.cloud.artifactregistry:artifactregistry-gradle-plugin:2.2.4"
   }
 }
 
@@ -120,7 +154,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath "gradle.plugin.com.google.cloud.artifactregistry:artifactregistry-gradle-plugin:2.2.1"
+    classpath "gradle.plugin.com.google.cloud.artifactregistry:artifactregistry-gradle-plugin:2.2.4"
   }
 }
 

--- a/artifactregistry-gradle-plugin/src/main/java/com/google/cloud/artifactregistry/gradle/plugin/ArtifactRegistryGradlePlugin.java
+++ b/artifactregistry-gradle-plugin/src/main/java/com/google/cloud/artifactregistry/gradle/plugin/ArtifactRegistryGradlePlugin.java
@@ -35,6 +35,7 @@ import org.gradle.api.artifacts.repositories.PasswordCredentials;
 import org.gradle.api.credentials.Credentials;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.initialization.dsl.ScriptHandler;
+import org.gradle.api.initialization.resolve.DependencyResolutionManagement;
 import org.gradle.api.internal.artifacts.repositories.DefaultMavenArtifactRepository;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.provider.Property;
@@ -156,10 +157,8 @@ public class ArtifactRegistryGradlePlugin implements Plugin<Object> {
   }
 
   private void modifySettings(Settings s, @Nullable ArtifactRegistryPasswordCredentials crd) {
-    final PluginManagementSpec pluginManagement = s.getPluginManagement();
-    if (pluginManagement != null) {
-      pluginManagement.getRepositories().forEach(r -> configureArtifactRegistryRepository(r, crd));
-    }
+    s.getPluginManagement().getRepositories().forEach(r -> configureArtifactRegistryRepository(r, crd));
+    s.getDependencyResolutionManagement().getRepositories().forEach(r -> configureArtifactRegistryRepository(r, crd));
   }
 
   private void configureArtifactRegistryRepository(


### PR DESCRIPTION
- Implements support for applying the Artifact Registry configuration to repositories defined within the `dependencyResolutionManagement` block.
  - Also cleans up some unnecessary null checks

- Adds documentation for using the `dependencyResolutionManagement` block in `settings.gradle` for managing dependency repositories.

- Also adds `local.properties` (created by Android Studio) to the .gitignore