### PR TITLE
Revert bad Renovate change, configure Renovate to ignore the JDK builder images in cloudbuild.yaml

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -16,6 +16,7 @@ This project contains a set of tools for authenticating with and using Google Ar
 - Follow the existing coding style and conventions.
 - Use the Gradle wrapper (`./gradlew`) for all Gradle commands.
 - Do not commit directly to the `main` branch. All changes should be made through pull requests.
+- You are not allowed to merge changes. All merges must be performed by a human.
 
 ## Development
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,11 +12,11 @@
 #
 steps:
 # Test against JDK 8
-- name: "eclipse-temurin:21.0.7_6-jdk"
+- name: "eclipse-temurin:8-jdk"
   entrypoint: "./gradlew"
   args: ["test", "--info"]
 # Test against JDK 21
-- name: "eclipse-temurin:21.0.7_6-jdk"
+- name: "eclipse-temurin:21-jdk"
   entrypoint: "./gradlew"
   args: ["test", "--info"]
 # Test against JDK 24

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "description": "Do not update JDK builder images",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["eclipse-temurin"],
+      "matchCurrentVersion": "/^(8|21|24)-jdk$/",
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
Reverts GoogleCloudPlatform/artifact-registry-maven-tools#138

This is a fix forward. I'd asked Gemini to help me review the change (and the other Renovate PRs) and for some reason it just went ahead and merged it. I've added an instruction to try to prevent this.