### PR TITLE
feat(renovate): group non-major dependency updates

### DIFF
--- a/artifactregistry-auth-common/build.gradle
+++ b/artifactregistry-auth-common/build.gradle
@@ -1,11 +1,11 @@
 dependencies {
-    implementation('com.google.http-client:google-http-client:1.46.3')
-    implementation('com.google.http-client:google-http-client-jackson2:1.46.3')
-    implementation('com.google.auth:google-auth-library-oauth2-http:1.33.1')
-    implementation group: 'org.slf4j', name: 'slf4j-api', version:'2.0.17'
+    implementation(libs.google.http.client)
+    implementation(libs.google.http.client.jackson2)
+    implementation(libs.google.auth.library.oauth2.http)
+    implementation(libs.slf4j.api)
 
     // override any guava:*-android dependency with jre dependency
-    implementation group: 'com.google.guava', name: 'guava', version:'33.4.6-jre'
+    implementation(libs.guava)
 
     // Exclude stuff that we don't need that bring in a ton of transitive deps.
     configurations.implementation {
@@ -17,5 +17,5 @@ dependencies {
         exclude group: 'com.google.j2objc', module: 'j2objc-annotations'
     }
 
-    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
+    testImplementation(libs.junit)
 }

--- a/artifactregistry-gradle-plugin/build.gradle
+++ b/artifactregistry-gradle-plugin/build.gradle
@@ -1,11 +1,11 @@
 plugins {
     id 'java-gradle-plugin'
-    id 'com.gradle.plugin-publish' version '1.3.1'
+    alias(libs.plugins.gradle.plugin.publish)
 }
 
 dependencies {
 	implementation gradleApi()
-	implementation group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version: '1.33.1'
+	implementation(libs.google.auth.library.oauth2.http)
 }
 
 gradlePlugin {
@@ -21,4 +21,3 @@ gradlePlugin {
         }
     }
 }
-

--- a/artifactregistry-maven-wagon/build.gradle
+++ b/artifactregistry-maven-wagon/build.gradle
@@ -1,11 +1,11 @@
 dependencies {
-    implementation group: 'org.apache.maven.wagon', name: 'wagon-http-shared', version: '3.5.3'
-    implementation group: 'org.apache.maven', name: 'maven-plugin-api', version: '3.9.10'
-    implementation('com.google.http-client:google-http-client:1.46.3')
-    implementation group: 'com.google.auth', name: 'google-auth-library-oauth2-http', version:'1.33.1'
+    implementation(libs.maven.wagon.http.shared)
+    implementation(libs.maven.plugin.api)
+    implementation(libs.google.http.client)
+    implementation(libs.google.auth.library.oauth2.http)
 
     // override any guava:*-android dependency with jre dependency
-    implementation group: 'com.google.guava', name: 'guava', version:'33.4.6-jre'
+    implementation(libs.guava)
 
     // Exclude stuff that we don't need that bring in a ton of transitive deps.
     configurations.implementation {
@@ -17,7 +17,7 @@ dependencies {
         exclude group: 'com.google.j2objc', module: 'j2objc-annotations'
     }
 
-    testImplementation group: 'org.apache.maven.wagon', name: 'wagon-provider-test', version: '3.5.3'
-    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    compileOnly group: 'org.apache.maven.wagon', name: 'wagon-provider-api', version: '3.5.3'
+    testImplementation(libs.maven.wagon.provider.test)
+    testImplementation(libs.junit)
+    compileOnly(libs.maven.wagon.provider.api)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,24 @@
+[versions]
+google-http-client = "1.46.3"
+google-auth-library-oauth2-http = "1.33.1"
+slf4j = "2.0.17"
+guava = "33.4.6-jre"
+junit = "4.13.2"
+maven-wagon = "3.5.3"
+maven-plugin-api = "3.9.10"
+gradle-plugin-publish = "1.3.1"
+
+[libraries]
+google-http-client = { group = "com.google.http-client", name = "google-http-client", version.ref = "google-http-client" }
+google-http-client-jackson2 = { group = "com.google.http-client", name = "google-http-client-jackson2", version.ref = "google-http-client" }
+google-auth-library-oauth2-http = { group = "com.google.auth", name = "google-auth-library-oauth2-http", version.ref = "google-auth-library-oauth2-http" }
+slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
+guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+maven-wagon-http-shared = { group = "org.apache.maven.wagon", name = "wagon-http-shared", version.ref = "maven-wagon" }
+maven-plugin-api = { group = "org.apache.maven", name = "maven-plugin-api", version.ref = "maven-plugin-api" }
+maven-wagon-provider-test = { group = "org.apache.maven.wagon", name = "wagon-provider-test", version.ref = "maven-wagon" }
+maven-wagon-provider-api = { group = "org.apache.maven.wagon", name = "wagon-provider-api", version.ref = "maven-wagon" }
+
+[plugins]
+gradle-plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "gradle-plugin-publish" }

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,15 @@
       "matchPackageNames": ["eclipse-temurin"],
       "matchCurrentVersion": "/^(8|21|24)-jdk$/",
       "enabled": false
+    },
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "groupName": "all non-major dependency updates"
     }
   ]
 }


### PR DESCRIPTION
This change configures Renovate to group all minor, patch, pin, and digest updates into a single pull request to reduce noise.