### PR TITLE
  refactor: Standardize on per-project JVM toolchains

### DIFF
--- a/artifactregistry-auth-common/build.gradle
+++ b/artifactregistry-auth-common/build.gradle
@@ -1,3 +1,10 @@
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
+
 dependencies {
     implementation(libs.google.http.client)
     implementation(libs.google.http.client.jackson2)

--- a/artifactregistry-gradle-plugin/build.gradle
+++ b/artifactregistry-gradle-plugin/build.gradle
@@ -3,6 +3,12 @@ plugins {
     alias(libs.plugins.gradle.plugin.publish)
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
+
 dependencies {
 	implementation gradleApi()
 	implementation(libs.google.auth.library.oauth2.http)

--- a/artifactregistry-maven-wagon/build.gradle
+++ b/artifactregistry-maven-wagon/build.gradle
@@ -1,3 +1,9 @@
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
+
 dependencies {
     implementation(libs.maven.wagon.http.shared)
     implementation(libs.maven.plugin.api)

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,7 @@ allprojects {
     apply plugin: 'maven-publish'
     group = 'com.google.cloud.artifactregistry'
     version = project_version
-    sourceCompatibility = 1.8
-    targetCompatibility = 1.8
+
     tasks.withType(JavaCompile) {
         options.encoding = 'UTF-8'
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,0 @@
-rootProject.name = 'artifactregistry-maven-tools'
-include 'artifactregistry-maven-wagon'
-include 'artifactregistry-auth-common'
-include 'artifactregistry-gradle-plugin'

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention").version("0.10.0")
+}
+
+rootProject.name = "artifactregistry-maven-tools"
+include("artifactregistry-maven-wagon")
+include("artifactregistry-auth-common")
+include("artifactregistry-gradle-plugin")


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #143

## Chain of upstream PRs as of 2025-06-27

* PR #142:
  `master` ← `feature/configure-renovate-grouping`

  * PR #143:
    `feature/configure-renovate-grouping` ← `froeht/version-cat`

    * **PR #144 (THIS ONE)**:
      `froeht/version-cat` ← `froeht/JavaToolchains`

<!-- end git-machete generated -->

  This commit modernizes and standardizes the project's Java version management by adopting Gradle's JVM toolchain feature. This change ensures a more consistent and reliable build process by decoupling the JDK required to run Gradle from the JDK used to compile the project's source code.


  By defining toolchains for each subproject, we eliminate ambiguity and reliance on the host machine's configured JAVA_HOME, making the build more portable and deterministic. As commended by the official Gradle documentation, this approach is preferred over setting sourceCompatibility and targetCompatibility directly.


  Key Changes:


   * Migrated to `settings.gradle.kts`: The settings file was converted to the Kotlin DSL to support modern Gradle features and improve type safety.
   * Adopted Foojay Toolchain Resolver: The `org.gradle.toolchains.foojay-resolver-convention` plugin (https://docs.gradle.org/current/userguide/toolchains.html#sec:foojay-resolver) has been added to automatically discover and provision the required JDKs.
   * Per-Project Toolchain Configuration: Each Java subproject (artifactregistry-auth-common, artifactregistry-gradle-plugin, and artifactregistry-maven-wagon) is now explicitly configured to compile against a Java 8 toolchain.
   * Removed Legacy Compatibility Settings: The root build.gradle no longer defines sourceCompatibility or targetCompatibility, as this is now managed centrally and more robustly by the toolchain configuration (https://docs.gradle.org/current/userguide/building_java_projects.html#sec:java_cross_compilation).
